### PR TITLE
calendar app bugfix

### DIFF
--- a/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
@@ -748,7 +748,6 @@ void drawCalendarMonth(int monthOffset) {
     int y = GRID_Y + row * CELL_H;
     display.fillRect(x, y, CELL_W, CELL_H, GxEPD_WHITE);
   }
-  Serial.println(daysInMonth);
   // Step 6: Draw day numbers and events
   for (int i = 0; i < daysInMonth; ++i) {
     int dayIndex = i + startDay;     // total box index in the 7x6 grid


### PR DESCRIPTION
in month view, calendar app was rendering day numbers up to 48 past the valid 31 days, because the datetime logic added 1 to the month, caused 13th month logic

steps to reproduce: open calendar app, go to december in month view