### PR TITLE
TXT bug

### DIFF
--- a/Code/PocketMage_V3/src/OS_APPS/TXT_NEW.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/TXT_NEW.cpp
@@ -1357,6 +1357,19 @@ void editAppend(char inchar) {
   }
   // ENTER Received
   else if (inchar == 13) {
+    // Check if false blank line
+    bool hasAnyText = false;
+    for (auto& ln : editingDocLine.lines) {
+      if (lineHasText(ln)) {
+        hasAnyText = true;
+        break;
+      }
+    }
+    if (hasAnyText && editingDocLine.style == 'B') {
+      editingDocLine.style = 'T';
+    }
+
+    // Line types
     // Horizontal Rule
     if (editingDocLine.style == 'H') {
       editingDocLine.line = "---";


### PR DESCRIPTION
Fixed a bug where blank lines that actually had text on them would not display and save properly. "Blank" lines are converted to body if they have text on them.