### PR TITLE
Reorder USB Deinit

### DIFF
--- a/Code/PocketMage_V3/src/OS_APPS/USB.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/USB.cpp
@@ -21,10 +21,6 @@ void USBAppShutdown() {
   // Stop MSC functionality
   msc.end();
 
-  // Stop USB peripheral completely
-  USB.end();
-  delay(50);
-
   // Free card struct
   if (card) {
     free(card);


### PR DESCRIPTION
Deinitializes USB to prevent access being held by the USB app and reorder deinit.