### PR TITLE
Edit oled line

### DIFF
--- a/Code/PocketMage_V3/lib/PocketMage/include/pocketmage_oled.h
+++ b/Code/PocketMage_V3/lib/PocketMage/include/pocketmage_oled.h
@@ -24,7 +24,7 @@ public:
   
   // Main methods
   void oledWord(String word, bool allowLarge = false, bool showInfo = true);
-  void oledLine(String line, bool doProgressBar = true, String bottomMsg = "");
+  void oledLine(String line, int input_pos, bool doProgressBar = true, String bottomMsg = "");
   void oledScroll();
   void infoBar();
   void setPowerSave(bool enable);

--- a/Code/PocketMage_V3/src/OS_APPS/APPLOADER.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/APPLOADER.cpp
@@ -726,7 +726,7 @@ void processKB_APPLOADER() {
         //Make sure oled only updates at OLED_MAX_FPS
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false);
+          OLED().oledLine(currentLine, currentLine.length(), false);
         }
       }
       break;

--- a/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
@@ -961,7 +961,7 @@ void processKB_CALENDAR() {
         //Make sure oled only updates at OLED_MAX_FPS
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false);
+          OLED().oledLine(currentLine, currentLine.length(), false);
         }
       }
       break;
@@ -1031,7 +1031,7 @@ void processKB_CALENDAR() {
         //Make sure oled only updates at OLED_MAX_FPS
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false);
+          OLED().oledLine(currentLine, currentLine.length(), false);
         }
       }
       break;
@@ -1200,22 +1200,22 @@ void processKB_CALENDAR() {
           OLEDFPSMillis = currentMillis;
           switch(newEventState) {
             case 0:
-              OLED().oledLine(currentLine, false, "Enter the Event Name");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Event Name");
               break;
             case 1:
-              OLED().oledLine(currentLine, false, "Enter the Start Date (YYYYMMDD)");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Start Date (YYYYMMDD)");
               break;
             case 2:
-              OLED().oledLine(currentLine, false, "Enter the Start Time (HH:MM)");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Start Time (HH:MM)");
               break;
             case 3:
-              OLED().oledLine(currentLine, false, "Enter the Event Duration (HH:MM)");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Event Duration (HH:MM)");
               break;
             case 4:
-              OLED().oledLine(currentLine, false, "Enter the Repeat Code or \"Help\"");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Repeat Code or \"Help\"");
               break;
             case 5:
-              OLED().oledLine(currentLine, false, "Attach a Note to the Event");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Attach a Note to the Event");
               break;
           }
         }
@@ -1423,25 +1423,25 @@ void processKB_CALENDAR() {
           OLEDFPSMillis = currentMillis;
           switch(newEventState) {
             case -1:
-              OLED().oledLine(currentLine, false);
+              OLED().oledLine(currentLine, currentLine.length(), false);
               break;
             case 0:
-              OLED().oledLine(currentLine, false, "Enter the Event Name");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Event Name");
               break;
             case 1:
-              OLED().oledLine(currentLine, false, "Enter the Start Date (YYYYMMDD)");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Start Date (YYYYMMDD)");
               break;
             case 2:
-              OLED().oledLine(currentLine, false, "Enter the Start Time (HH:MM)");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Start Time (HH:MM)");
               break;
             case 3:
-              OLED().oledLine(currentLine, false, "Enter the Event Duration (HH:MM)");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Event Duration (HH:MM)");
               break;
             case 4:
-              OLED().oledLine(currentLine, false, "Enter the Repeat Code or \"Help\"");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Enter the Repeat Code or \"Help\"");
               break;
             case 5:
-              OLED().oledLine(currentLine, false, "Attach a Note to the Event");
+              OLED().oledLine(currentLine, currentLine.length(), false, "Attach a Note to the Event");
               break;
           }
         }
@@ -1567,7 +1567,7 @@ void processKB_CALENDAR() {
         //Make sure oled only updates at OLED_MAX_FPS
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false);
+          OLED().oledLine(currentLine, currentLine.length(), false);
         }
       }
       break;

--- a/Code/PocketMage_V3/src/OS_APPS/FILEWIZ.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/FILEWIZ.cpp
@@ -395,7 +395,7 @@ void processKB_FILEWIZ() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
         KBBounceMillis = currentMillis;
       }
@@ -439,7 +439,7 @@ void processKB_FILEWIZ() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
         KBBounceMillis = currentMillis;
       }
@@ -522,7 +522,7 @@ void processKB_FILEWIZ() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
       }
       break;
@@ -604,7 +604,7 @@ void processKB_FILEWIZ() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
       }
       break;

--- a/Code/PocketMage_V3/src/OS_APPS/TASKS.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/TASKS.cpp
@@ -268,7 +268,7 @@ void processKB_TASKS() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false);
+          OLED().oledLine(currentLine, currentLine.length(), false);
         }
       }
       break;

--- a/Code/PocketMage_V3/src/OS_APPS/TXT.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/TXT.cpp
@@ -158,7 +158,7 @@ void processKB_TXT_OLD() {
           OLEDFPSMillis = currentMillis;
           // ONLY SHOW OLEDLINE WHEN NOT IN SCROLL MODE
           if (TOUCH().getLastTouch() == -1) {
-            OLED().oledLine(currentLine);
+            OLED().oledLine(currentLine, currentLine.length());
             if (TOUCH().getPrevDynamicScroll() != TOUCH().getDynamicScroll()) TOUCH().setPrevDynamicScroll(TOUCH().getDynamicScroll());
           }
           else OLED().oledScroll();
@@ -246,7 +246,7 @@ void processKB_TXT_OLD() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(),false);
         }
         break;
       case WIZ1:
@@ -308,7 +308,7 @@ void processKB_TXT_OLD() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
         break;
 
@@ -383,7 +383,7 @@ void processKB_TXT_OLD() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
         break;
       case WIZ3:
@@ -450,7 +450,7 @@ void processKB_TXT_OLD() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
         break;
       case FONT:
@@ -512,7 +512,7 @@ void processKB_TXT_OLD() {
         //Make sure oled only updates at 60fps
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentWord, false);
+          OLED().oledLine(currentWord, currentWord.length(), false);
         }
         break;
 

--- a/Code/PocketMage_V3/src/OS_APPS/TXT_NEW.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/TXT_NEW.cpp
@@ -1935,7 +1935,7 @@ void processKB_TXT_NEW() {
         //Make sure oled only updates at OLED_MAX_FPS
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false, "Input Filename");
+          OLED().oledLine(currentLine, currentLine.length(), false, "Input Filename");
         }
       }
       break;
@@ -1999,7 +1999,7 @@ void processKB_TXT_NEW() {
         //Make sure oled only updates at OLED_MAX_FPS
         if (currentMillis - OLEDFPSMillis >= (1000/OLED_MAX_FPS)) {
           OLEDFPSMillis = currentMillis;
-          OLED().oledLine(currentLine, false, "Input Name for New File");
+          OLED().oledLine(currentLine, currentLine.length(), false, "Input Name for New File");
         }
       }
       break;

--- a/Code/PocketMage_V3/src/OS_APPS/USB.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/USB.cpp
@@ -201,7 +201,7 @@ void processKB_USB() {
   //Make sure oled only updates at 10FPS
   if (currentMillis - OLEDFPSMillis >= (1000/10 /*OLED_MAX_FPS*/)) {
     OLEDFPSMillis = currentMillis;
-    OLED().oledLine(currentLine, false);
+    OLED().oledLine(currentLine, currentLine.length(), false);
   }
   
   if (currentMillis - KBBounceMillis >= KB_COOLDOWN) {  


### PR DESCRIPTION
Functionality for editing a line on the oled display.  A start to addressing https://github.com/ashtf8/PocketMage_PDA/issues/119

Arrow keys move the cursor left and right, circle jumps to the end of the line.  Insert, delete, scrolling all works.
Easiest test is to simply type stuff on the HOME screen.

HOME, SETTINGS, LEXICON updated to use it.

Other apps are a bit more complicated so they were only updated for the new function definition but I left the functionality the same.  I'll address them individually if we're good with the way this works.

Other notes: "ESC/CANCEL/CLEAR" was changed to char 29 (SHIFT+circle) since I used circle for end of line.
There probably needs to be some decisions made on consistent key combos.  