### PR TITLE
Fix calendar power cleanup on file-open failure

### DIFF
--- a/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
@@ -49,6 +49,8 @@ void updateEventArray() {
   File file = global_fs->open("/sys/events.txt", "r"); // Open the text file in read mode
   if (!file) {
     ESP_LOGE(TAG, "Failed to open file for reading: %s", file.path());
+    if (SAVE_POWER) pocketmage::setCpuSpeed(POWER_SAVE_FREQ);
+    SDActive = false;
     return;
   }
 


### PR DESCRIPTION
   ## Summary

   Fix `updateEventArray()` so a failed open of `/sys/events.txt` restores the
   normal power state before returning.

   ## Change

   - reset `SDActive = false`
   - restore `POWER_SAVE_FREQ` when `SAVE_POWER` is enabled

   ## Why

   Previously, this failure path returned early and could leave the system in a
   stale "SD active" / boosted CPU state.