### PR TITLE
Update broken links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@
 # [Getting Started]
 **Helpful Resources:**
 
-[FAQ](https://github.com/ashtf8/PocketMage_PDA/tree/main/Docs/FAQ)
+[FAQ](https://github.com/ashtf8/PocketMage_PDA/tree/main/Docs/Getting%20Started/FAQ)
 
-[Tutorials](https://github.com/ashtf8/PocketMage_PDA/tree/main/Docs/Tutorials)
+[Tutorials](https://github.com/ashtf8/PocketMage_PDA/tree/main/Docs/Getting%20Started/Tutorials)
 
 [PocketMage Command & Keystroke Manual](https://github.com/ashtf8/PocketMage_PDA/tree/main/Docs/Getting%20Started/Command%20Manual)
 


### PR DESCRIPTION
Fixed the FAQ and Tutorials links that were broken when those were moved to the `/Docs/Getting Started/` folder.

(I went looking for a format for PRs and didn’t find one. Let me know if there’s anything else you need to know)