### PR TITLE
feat(calendar): add option for weeks to start on Monday (closes #120)

### DIFF
--- a/Code/PocketMage_V3/include/globals.h
+++ b/Code/PocketMage_V3/include/globals.h
@@ -27,6 +27,8 @@ extern volatile bool disableTimeout;            // Disable timeout globally
 extern bool fileLoaded;     
 extern unsigned int flashMillis;                // Flash timing
 
+extern bool WEEK_START_MONDAY;                 // Calendar weeks start on Monday
+
 extern String OTA1_APP;
 extern String OTA2_APP;
 extern String OTA3_APP;

--- a/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/CALENDAR.cpp
@@ -431,12 +431,14 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day()); 
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedSunday = currentSunday + TimeSpan(weekOffsetCount * 7, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 6 : 0;  // Sun is last day (Mon start) or first day (Sun start)
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
-    currentDate  = viewedSunday.day();
-    currentMonth = viewedSunday.month();
-    currentYear  = viewedSunday.year();
+    currentDate  = viewedDay.day();
+    currentMonth = viewedDay.month();
+    currentYear  = viewedDay.year();
 
     newState = true;
     KB().setKeyboardState(NORMAL);
@@ -447,12 +449,14 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day());
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedMonday = currentSunday + TimeSpan(weekOffsetCount * 7 + 1, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 0 : 1;  // Mon is first day (Mon start) or second day (Sun start)
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
-    currentDate  = viewedMonday.day();
-    currentMonth = viewedMonday.month();
-    currentYear  = viewedMonday.year();
+    currentDate  = viewedDay.day();
+    currentMonth = viewedDay.month();
+    currentYear  = viewedDay.year();
 
     newState = true;
     KB().setKeyboardState(NORMAL);
@@ -463,12 +467,14 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day());
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedTuesday = currentSunday + TimeSpan(weekOffsetCount * 7 + 2, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 1 : 2;
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
-    currentDate  = viewedTuesday.day();
-    currentMonth = viewedTuesday.month();
-    currentYear  = viewedTuesday.year();
+    currentDate  = viewedDay.day();
+    currentMonth = viewedDay.month();
+    currentYear  = viewedDay.year();
 
     newState = true;
     KB().setKeyboardState(NORMAL);
@@ -479,12 +485,14 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day());
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedWednesday = currentSunday + TimeSpan(weekOffsetCount * 7 + 3, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 2 : 3;
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
-    currentDate  = viewedWednesday.day();
-    currentMonth = viewedWednesday.month();
-    currentYear  = viewedWednesday.year();
+    currentDate  = viewedDay.day();
+    currentMonth = viewedDay.month();
+    currentYear  = viewedDay.year();
 
     newState = true;
     KB().setKeyboardState(NORMAL);
@@ -495,8 +503,10 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day());
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedThursday = currentSunday + TimeSpan(weekOffsetCount * 7 + 4, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 3 : 4;
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
     currentDate  = viewedThursday.day();
     currentMonth = viewedThursday.month();
@@ -511,12 +521,14 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day());
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedFriday = currentSunday + TimeSpan(weekOffsetCount * 7 + 5, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 4 : 5;
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
-    currentDate  = viewedFriday.day();
-    currentMonth = viewedFriday.month();
-    currentYear  = viewedFriday.year();
+    currentDate  = viewedDay.day();
+    currentMonth = viewedDay.month();
+    currentYear  = viewedDay.year();
 
     newState = true;
     KB().setKeyboardState(NORMAL);
@@ -527,12 +539,14 @@ void commandSelectWeek(String command) {
 
     DateTime now = CLOCK().nowDT();
     int todayDOW = getDayOfWeek(now.year(), now.month(), now.day());
-    DateTime currentSunday = now - TimeSpan(todayDOW, 0, 0, 0);
-    DateTime viewedSaturday = currentSunday + TimeSpan(weekOffsetCount * 7 + 6, 0, 0, 0);
+    int daysBack = WEEK_START_MONDAY ? ((todayDOW == 0) ? 6 : todayDOW - 1) : todayDOW;
+    DateTime weekStart = now - TimeSpan(daysBack, 0, 0, 0);
+    int dayOffset = WEEK_START_MONDAY ? 5 : 6;
+    DateTime viewedDay = weekStart + TimeSpan(weekOffsetCount * 7 + dayOffset, 0, 0, 0);
 
-    currentDate  = viewedSaturday.day();
-    currentMonth = viewedSaturday.month();
-    currentYear  = viewedSaturday.year();
+    currentDate  = viewedDay.day();
+    currentMonth = viewedDay.month();
+    currentYear  = viewedDay.year();
 
     newState = true;
     KB().setKeyboardState(NORMAL);
@@ -735,9 +749,26 @@ void drawCalendarMonth(int monthOffset) {
   EINK().drawStatusBar(getMonthName(currentMonth) + " " + String(currentYear)+ " | Type a Date:");
   display.drawBitmap(0, 0, calendar_allArray[1], 320, 218, GxEPD_BLACK);
 
+  // Overlay and redraw day-of-week headers if week starts on Monday
+  if (WEEK_START_MONDAY) {
+    const char* dayHeaders[] = { "M", "T", "W", "T", "F", "S", "S" };
+    display.fillRect(GRID_X, 33, 7 * CELL_W, 16, GxEPD_WHITE);
+    display.setFont(&FreeSerif9pt7b);
+    display.setTextColor(GxEPD_BLACK);
+    for (int i = 0; i < 7; i++) {
+      display.setCursor(GRID_X + i * CELL_W + 17, 46);
+      display.print(dayHeaders[i]);
+    }
+  }
+
   // Step 2: Day of the week for the 1st of the month (0 = Sun, 6 = Sat)
   DateTime firstDay(year, month, 1);
   int startDay = firstDay.dayOfTheWeek();  // 0–6, Sun to Sat
+
+  // Adjust for Monday-start weeks: Mon=0, Tue=1, ..., Sun=6
+  if (WEEK_START_MONDAY) {
+    startDay = (startDay + 6) % 7;
+  }
 
   // Step 3: Number of days in the month
   int nextYear  = (month == 12) ? (year + 1) : year;
@@ -807,6 +838,18 @@ void drawCalendarWeek(int weekOffset) {
   EINK().drawStatusBar("Type Sun, etc. or (N)ew");
   display.drawBitmap(0, 0, calendar_allArray[0], 320, 218, GxEPD_BLACK);
 
+  // Overlay and redraw day-of-week headers if week starts on Monday
+  if (WEEK_START_MONDAY) {
+    const char* dayHeaders[] = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
+    display.fillRect(7, 33, 7 * 44, 16, GxEPD_WHITE);
+    display.setFont(&Font5x7Fixed);
+    display.setTextColor(GxEPD_BLACK);
+    for (int i = 0; i < 7; i++) {
+      display.setCursor(9 + (i * 44) + 8, 45);
+      display.print(dayHeaders[i]);
+    }
+  }
+
   // Get current date
   DateTime now = CLOCK().nowDT();
   int year = now.year();
@@ -814,8 +857,14 @@ void drawCalendarWeek(int weekOffset) {
   int day = now.day();
   int dow = now.dayOfTheWeek();  // 0 = Sunday
 
-  // Calculate how many days to go back to get to Sunday, adjusted by weekOffset
-  int totalOffset = -dow + (weekOffset * 7);
+  // Calculate how many days to go back to get to start of week, adjusted by weekOffset
+  int daysBack;
+  if (WEEK_START_MONDAY) {
+    daysBack = (dow == 0) ? 6 : dow - 1;  // Monday = 0 days back, Sunday = 6 days back
+  } else {
+    daysBack = dow;  // Sunday = 0 days back (original behavior)
+  }
+  int totalOffset = -daysBack + (weekOffset * 7);
 
   for (int i = 0; i < 7; i++) {
     // Compute day offset from today

--- a/Code/PocketMage_V3/src/OS_APPS/SETTINGS.cpp
+++ b/Code/PocketMage_V3/src/OS_APPS/SETTINGS.cpp
@@ -217,6 +217,21 @@ String settingCommandSelect(String command) {
     newState = true;
     return "Settings Updated";
   }
+  else if (command.startsWith("weekstart ")) {
+    String weekPart = command.substring(10);
+    weekPart.trim();
+
+    if (weekPart != "t" && weekPart != "f") return "Invalid";
+
+    WEEK_START_MONDAY = (weekPart == "t");
+    
+    prefs.begin("PocketMage", false);
+    prefs.putBool("WEEK_START_MON", WEEK_START_MONDAY);
+    prefs.end();
+    
+    newState = true;
+    return "Settings Updated";
+  }
   else if (command.startsWith("allownosd ")) {
     String noSDPart = command.substring(10);
     noSDPart.trim();
@@ -293,6 +308,13 @@ void einkHandler_settings() {
     // OLED_MAX_FPS
     display.setCursor(163, 42);
     display.print(String(OLED_MAX_FPS).c_str());
+    // WEEK_START_MONDAY
+    display.setFont(&Font5x7Fixed);
+    display.setCursor(163, 60);
+    display.print("WeekStart:");
+    if (WEEK_START_MONDAY) display.drawBitmap(163, 63, _toggleON, 26, 11, GxEPD_BLACK);
+    else display.drawBitmap(163, 63, _toggleOFF, 26, 11, GxEPD_BLACK);
+    display.setFont(&FreeSerif9pt7b);
 
     EINK().drawStatusBar("Type a Command:");
 

--- a/Code/PocketMage_V3/src/UTILS.cpp
+++ b/Code/PocketMage_V3/src/UTILS.cpp
@@ -179,6 +179,7 @@ void loadState(bool changeState) {
   HOME_ON_BOOT = prefs.getBool("HOME_ON_BOOT", false);
   OLED_BRIGHTNESS = prefs.getInt("OLED_BRIGHTNESS", 255);
   OLED_MAX_FPS = prefs.getInt("OLED_MAX_FPS", 60);
+  WEEK_START_MONDAY = prefs.getBool("WEEK_START_MON", false);
 
   OTA1_APP = prefs.getString("OTA1", "-");
   OTA2_APP = prefs.getString("OTA2", "-");

--- a/Code/PocketMage_V3/src/globals.cpp
+++ b/Code/PocketMage_V3/src/globals.cpp
@@ -31,6 +31,7 @@ bool HOME_ON_BOOT;                       // Start home app on boot
 int OLED_BRIGHTNESS;                     // OLED brightness (0-255)
 int OLED_MAX_FPS;                        // OLED max FPS
 bool SD_SPI_COMPATIBILITY;               // SD card compatibility mode
+bool WEEK_START_MONDAY;                  // Calendar weeks start on Monday
 
 // ===================== APP STATES =====================
 const String appStateNames[] = { "txt", "filewiz", "usb", "bt", "settings", "tasks", "calendar", "journal", "lexicon", "terminal" , "loader" }; // App state names


### PR DESCRIPTION
# PR: Add option for weeks to start on Monday

**Closes #120**

## Summary

Adds a user-configurable setting (`weekstart t/f`) that allows calendar weeks to start on Monday instead of Sunday. The setting is persisted in NVS and defaults to `false` (Sunday start) for backward compatibility.

## Changes

### New setting: `WEEK_START_MONDAY`

- **globals.h / globals.cpp**: Added `WEEK_START_MONDAY` global bool
- **UTILS.cpp**: Loads from NVS preferences on boot (`"WEEK_START_MON"`, default `false`)
- **SETTINGS.cpp**: Added `weekstart t` / `weekstart f` command. Toggle is displayed in the second column of the Settings screen

### Calendar: Month View (`drawCalendarMonth`)

- When `WEEK_START_MONDAY` is enabled, the grid column offset for day 1 is shifted so Monday occupies column 0 and Sunday occupies column 6
- The bitmap day-of-week header row is overlaid with a white rectangle and redrawn programmatically with the correct order (M T W T F S S)

### Calendar: Week View (`drawCalendarWeek`)

- The week anchor shifts from Sunday to Monday when enabled
- Day-of-week headers are overlaid and redrawn (Mon Tue Wed Thu Fri Sat Sun)

### Calendar: Week Navigation (`commandSelectWeek`)

- All seven day handlers (Sun, Mon, Tue, Wed, Thu, Fri, Sat) compute the week anchor dynamically based on `WEEK_START_MONDAY`, ensuring correct date calculation when navigating by day name

## How to use

1. Open the **Settings** app
2. Type `weekstart t` and press Enter to enable Monday-start weeks
3. Type `weekstart f` to revert to Sunday-start

The setting persists across reboots.

## Known limitations

- The individual **Day View** bitmaps (`_calendar04` through `_calendar10`) still display the original Sun–Sat column header order baked into the bitmap assets. The overlay approach used in Month and Week views works well for those screens, but updating the Day View bitmaps would require asset-level changes (separate effort).
- Without hardware for testing, the exact Y-coordinate for the header overlay (Y=33, height=16px) was estimated from grid geometry. May need minor pixel adjustment on-device.

## Testing notes

This was developed as a blind contribution (no hardware). Recommended test cases:

1. **Default behavior preserved**: With `weekstart f` (default), verify Month and Week views display Sun–Sat as before
2. **Monday start — Month view**: Enable `weekstart t`, verify the month grid shows M T W T F S S headers and day numbers align correctly (e.g., if the 1st is a Wednesday, it should appear in column 3)
3. **Monday start — Week view**: Verify the week starts on Monday and navigation arrows step through Mon–Sun
4. **Day name navigation**: In Week view, type `mon`, `tue`, etc. and verify dates are correct for the displayed week
5. **Month boundary**: Navigate to months where the 1st falls on Sunday or Monday to verify no off-by-one errors
6. **Persistence**: Set `weekstart t`, reboot, verify setting is retained
