### PR TITLE
docs: fix dead ashtf8.github.io links

### DIFF
--- a/Docs/README.md
+++ b/Docs/README.md
@@ -2,7 +2,7 @@
 
 The documentation site for the PocketMage PDA project.
 
-**Live docs: https://ashtf8.github.io/PocketMage_PDA/docs/**
+**Live docs: https://tailsmandesign.github.io/PocketMage_PDA/docs/**
 
 ---
 
@@ -64,6 +64,6 @@ Keep language clear and direct.
 
 ## Project links
 
-- Main repo: https://github.com/ashtf8/PocketMage_PDA
+- Main repo: https://github.com/TailsmanDesign/PocketMage_PDA
 - Discord: https://discord.gg/KSCapSf4XH
 - Website: https://pocketmage.org/

--- a/Docs/docmd.config.js
+++ b/Docs/docmd.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   siteTitle: "PocketMage Documentation",
-  siteUrl: "https://ashtf8.github.io/PocketMage_PDA/docs",
+  siteUrl: "https://tailsmandesign.github.io/PocketMage_PDA/docs",
   logo: { alt: "PocketMage", href: "./", light: "/assets/favicon.png", dark: "/assets/favicon.png" },
   favicon: "/assets/favicon.png",
   srcDir: "docs",
@@ -34,7 +34,7 @@ module.exports = {
         { title: "OLED Drawing Script", path: "/tutorials/oled-c", icon: "monitor" },
       ],
     },
-    { title: "GitHub", path: "https://github.com/ashtf8/PocketMage_PDA", icon: "github", external: true },
+    { title: "GitHub", path: "https://github.com/TailsmanDesign/PocketMage_PDA", icon: "github", external: true },
   ],
   footer: "Built with docmd.",
 };

--- a/Docs/docs/faq/index.md
+++ b/Docs/docs/faq/index.md
@@ -11,7 +11,7 @@ description: "Frequently asked questions about the PocketMage PDA device."
 
 [PocketMage.org](https://pocketmage.org/)
 
-[PocketMage - GitHub](https://github.com/ashtf8/PocketMage_PDA)
+[PocketMage - GitHub](https://github.com/TailsmanDesign/PocketMage_PDA)
 
 [PocketMage - Discord](https://discord.gg/KSCapSf4XH)
 
@@ -61,7 +61,7 @@ The video build guide can be found [here.](https://youtu.be/2aNcC0qCK1o?si=HKqUI
 
 ### **Is there a guide on the key operations?**
 
-Yes! That guide can be found [here.](https://github.com/ashtf8/PocketMage_PDA/tree/main/Docs/Getting%20Started/Command%20Manual)
+Yes! That guide can be found [here.](https://github.com/TailsmanDesign/PocketMage_PDA/tree/main/Docs/Getting%20Started/Command%20Manual)
 
 ### **How do I flash the firmware?**
 
@@ -71,7 +71,7 @@ Then, ensure the DIP switch for programming mode is switched to the ON position.
 
 Next, hold the power button while plugging your PocketMage into your computer, **nothing should happen**.
 
-Next, navigate to [The Web Flasher](https://ashtf8.github.io/PocketMage_PDA/) in a **chrome-based browser** and select your firmware version. The **most recent stable build** (highest number) is recommended.
+Next, navigate to [The Web Flasher](https://tailsmandesign.github.io/PocketMage_PDA/) in a **chrome-based browser** and select your firmware version. The **most recent stable build** (highest number) is recommended.
 
 If you would like to keep your saved settings, ensure that the "Preserve user data during installation" check box is **checked**.
 
@@ -87,7 +87,7 @@ You can use any microSD card up to 32gb. **8gb is recommended** since PocketMage
 
 ### **Where are the CAD files?**
 
-Currently CAD files are available only to Beta Testers. These files will be released to the public alongside the release of the final production PocketMage. If you are a Beta Tester, you can find the password-protected .zip file [here](https://github.com/ashtf8/PocketMage_PDA/tree/main/Resources/CAD) and the password in the beta Discord channel.
+Currently CAD files are available only to Beta Testers. These files will be released to the public alongside the release of the final production PocketMage. If you are a Beta Tester, you can find the password-protected .zip file [here](https://github.com/TailsmanDesign/PocketMage_PDA/tree/main/Resources/CAD) and the password in the beta Discord channel.
 
 ### **Where can I get an extra battery?**
 
@@ -103,7 +103,7 @@ The programming mode switch allows you to program and debug the PocketMage. Inte
 
 ### **My dictionary isn't working!**
 
-The English dictionary isn't installed on the PocketMage out of the box and needs to be downloaded to the SD card. Find the dictionary files [here.](<https://github.com/ashtf8/PocketMage_PDA/tree/main/Resources/Assets/Dictionary%20(OPTED)>) Simply connect your PocketMage to your computer using the USB app and drop all the .txt files into the dictionary folder!
+The English dictionary isn't installed on the PocketMage out of the box and needs to be downloaded to the SD card. Find the dictionary files [here.](<https://github.com/TailsmanDesign/PocketMage_PDA/tree/main/Resources/Assets/Dictionary%20(OPTED)>) Simply connect your PocketMage to your computer using the USB app and drop all the .txt files into the dictionary folder!
 
 ### **I can't flash the firmware!**
 
@@ -111,7 +111,7 @@ Ensure that: Your battery is unplugged and the programming mode DIP switch is se
 
 ### **I found a software bug!**
 
-Please report the bug in detail on the [GitHub issues page](https://github.com/ashtf8/PocketMage_PDA/issues) and include steps to reproduce. We will get to it when we can!
+Please report the bug in detail on the [GitHub issues page](https://github.com/TailsmanDesign/PocketMage_PDA/issues) and include steps to reproduce. We will get to it when we can!
 
 ### **My SD card isn't working!**
 

--- a/Docs/docs/index.md
+++ b/Docs/docs/index.md
@@ -17,7 +17,7 @@ Welcome to the official docs for the PocketMage open-source PDA! Here you'll fin
 ## Quick Links
 
 - [PocketMage.org](https://pocketmage.org/)
-- [GitHub Repository](https://github.com/ashtf8/PocketMage_PDA)
+- [GitHub Repository](https://github.com/TailsmanDesign/PocketMage_PDA)
 - [Discord Community](https://discord.gg/KSCapSf4XH)
 
 Start exploring by choosing a section above!

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ PocketMage is Pre-Launch on Crowd Supply! Check it out [here](https://pocketmage
 
 [PocketMage Command & Keystroke Manual](https://tailsmandesign.github.io/PocketMage_PDA/docs/command-manual)
 
-[3rd Party App Template](https://github.com/ashtf8/PocketMage_PDA/blob/main/Code/PocketMage_V3/src/APP_TEMPLATE.cpp)
+[3rd Party App Template](https://github.com/TailsmanDesign/PocketMage_PDA/blob/main/Code/PocketMage_V3/src/APP_TEMPLATE.cpp)
 
   Check the [APP_TEMPLATE.cpp](./Code/PocketMage_V3/src/APP_TEMPLATE.cpp) and [/Code/PocketMage_V3/src/readme.md](./Code/PocketMage_V3/src/readme.md) file for more information. Check out the following video as a tutorial on how to create and format your app:
 [Developing For the PocketMage](https://www.youtube.com/watch?v=3Ytc-3-BbMM)

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ PocketMage is Pre-Launch on Crowd Supply! Check it out [here](https://pocketmage
 # [Getting Started]
 **Helpful Resources:**
 
-[FAQ](https://ashtf8.github.io/PocketMage_PDA/docs/faq)
+[FAQ](https://tailsmandesign.github.io/PocketMage_PDA/docs/faq)
 
-[Tutorials](https://ashtf8.github.io/PocketMage_PDA/docs/tutorials)
+[Tutorials](https://tailsmandesign.github.io/PocketMage_PDA/docs/tutorials)
 
-[PocketMage Command & Keystroke Manual](https://ashtf8.github.io/PocketMage_PDA/docs/command-manual)
+[PocketMage Command & Keystroke Manual](https://tailsmandesign.github.io/PocketMage_PDA/docs/command-manual)
 
 [3rd Party App Template](https://github.com/ashtf8/PocketMage_PDA/blob/main/Code/PocketMage_V3/src/APP_TEMPLATE.cpp)
 


### PR DESCRIPTION
The docs site moved when the repo transferred from `ashtf8/PocketMage_PDA` to `TailsmanDesign/PocketMage_PDA`, but a few links were never updated:

- `README.md`: FAQ, Tutorials, and Command & Keystroke Manual links (all `ashtf8.github.io`, now 404)
- `Docs/docmd.config.js`: `siteUrl` and the nav "GitHub" entry

All four updated to the live `tailsmandesign.github.io` site and canonical repo URL. No functional/code changes.