### PR TITLE
fix: prevent upside-down screensaver, don't kill eink task mid-refresh

### DIFF
--- a/Code/PocketMage_V3/include/globals.h
+++ b/Code/PocketMage_V3/include/globals.h
@@ -20,6 +20,8 @@ extern fs::FS* global_fs;
 // ===================== SYSTEM STATE =====================
 extern Preferences prefs;                       // NVS preferencesv
 extern TaskHandle_t einkHandlerTaskHandle;      // E-Ink handler task
+extern volatile bool einkHandlerShouldExit;     // Signal einkHandler to exit cleanly
+extern volatile bool einkHandlerExited;         // Set by einkHandler once it has exited
 extern int OLEDFPSMillis;                       // Last OLED FPS update time
 extern int KBBounceMillis;                      // Last keyboard debounce time
 extern volatile bool newState;                  // App state changed

--- a/Code/PocketMage_V3/lib/PocketMage/src/pocketmage_eink.cpp
+++ b/Code/PocketMage_V3/lib/PocketMage/src/pocketmage_eink.cpp
@@ -13,6 +13,8 @@ static constexpr const char* tag = "EINK";
 GxEPD2_BW<GxEPD2_310_GDEQ031T10, GxEPD2_310_GDEQ031T10::HEIGHT> display(GxEPD2_310_GDEQ031T10(EPD_CS, EPD_DC, EPD_RST, EPD_BUSY));
 
 TaskHandle_t einkHandlerTaskHandle = NULL; // E-Ink handler task
+volatile bool einkHandlerShouldExit = false; // Signal einkHandler to exit cleanly
+volatile bool einkHandlerExited = false;     // Set by einkHandler once it has exited
 
 // Fast full update flag for e-ink
 volatile bool GxEPD2_310_GDEQ031T10::useFastFullUpdate = true;

--- a/Code/PocketMage_V3/lib/PocketMage/src/pocketmage_sys.cpp
+++ b/Code/PocketMage_V3/lib/PocketMage/src/pocketmage_sys.cpp
@@ -83,10 +83,25 @@ void deepSleep(bool alternateScreenSaver) {
   // Put OLED to sleep
   u8g2.setPowerSave(1);
 
-  // Stop the einkHandler task safely
+  // Stop the einkHandler task safely: signal it to finish whatever it's
+  // doing and exit on its own, rather than killing it mid-refresh (which
+  // could leave an e-ink SPI transaction half-done — see #278/#280).
+  // Still force-delete as a last resort so a stuck task can't prevent sleep.
   if (einkHandlerTaskHandle != NULL) {
-    vTaskDelete(einkHandlerTaskHandle);
+    einkHandlerExited = false;
+    einkHandlerShouldExit = true;
+
+    uint32_t waitedMs = 0;
+    constexpr uint32_t kMaxWaitMs = 500;
+    while (!einkHandlerExited && waitedMs < kMaxWaitMs) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      waitedMs += 10;
+    }
+    if (!einkHandlerExited) {
+      vTaskDelete(einkHandlerTaskHandle);
+    }
     einkHandlerTaskHandle = NULL;
+    einkHandlerShouldExit = false;
   }
 
   // Shutdown Jingle
@@ -112,7 +127,12 @@ void deepSleep(bool alternateScreenSaver) {
       dir.close();
     }
 
-    display.setFullWindow();
+    // Force rotation back to the standard orientation before drawing the
+    // screensaver — HOME_INIT() is the only place that overrides it, and
+    // that override would otherwise persist onto the screensaver bitmap if
+    // the device slept without passing through another app that resets it
+    // (see #280 — "renders upside down" depended on navigation history).
+    EINK().resetDisplay(false);
 
     // Use custom screensavers
     if (!binFiles.empty()) {

--- a/Code/PocketMage_V3/src/PocketMageV3.cpp
+++ b/Code/PocketMage_V3/src/PocketMageV3.cpp
@@ -180,11 +180,20 @@ void loop() {
 
 // E-Ink Loop
 void einkHandler(void* parameter) {
-  vTaskDelay(pdMS_TO_TICKS(250)); 
+  vTaskDelay(pdMS_TO_TICKS(250));
   for (;;) {
+    // Exit cleanly between operations rather than being vTaskDelete'd
+    // mid-refresh (see issue #278/#280 — killing this task while it's
+    // partway through an e-ink SPI transaction can corrupt the display).
+    if (einkHandlerShouldExit) break;
+
     applicationEinkHandler();
+
+    if (einkHandlerShouldExit) break;
 
     vTaskDelay(pdMS_TO_TICKS(50));
     yield();
   }
+  einkHandlerExited = true;
+  vTaskDelete(NULL);
 }


### PR DESCRIPTION
Fixes #280.

## What and why

Two compounding root causes, both traced by reading the actual eink/rotation/power-button code (see the earlier comments on #280 for the step-by-step investigation):

1. **Rotation leak.** `deepSleep()`'s screensaver draw never reset display rotation before drawing. `HOME_INIT()` is the only place that overrides rotation to `1` (180° from the standard `3`), so if the device passed through HOME earlier in the session and was then put to sleep from another app, the screensaver rendered upside down — matching the reporter's "there is a chance" wording, since it depends on navigation history. Now forces rotation back via `EINK().resetDisplay(false)` before drawing, matching the pattern already used in FILEWIZ/LEXICON/TASKS/CALENDAR.

2. **Unsafe task kill.** The power-button poll calls `deepSleep()` the moment it sees the button, with no check on what `einkHandlerTask` is doing. `deepSleep()` then `vTaskDelete()`'d that task outright, which could kill it mid e-ink SPI transaction (also implicated in #278's partial-clear symptom). `einkHandler()` now checks a `shouldExit` flag at safe points between operations and self-deletes cleanly; `deepSleep()` signals the flag and waits up to 500ms for confirmation before falling back to the old hard `vTaskDelete`, so a genuinely stuck task still can't block sleep.

## How I tested it

Full `PM_PRODUCTION` build succeeds cleanly (RAM 29.2%, Flash 75.3% — no meaningful size regression). No local unit-test harness exists for this project (confirmed during earlier onboarding), so I don't have a way to exercise the runtime behaviour myself. @NellowTCS — you offered to test this on real hardware when we discussed the approach on #280; would appreciate that here before merge, given the timing-dependent nature of the original bug.

## AI-assisted contribution

Drafted with an AI assistant (Claude Code), including the root-cause tracing on #280. Reviewed and the build-verified above by me; happy to explain any part of the diff.