### PR TITLE
Fix calendar event note wrapping

### DIFF
--- a/Code/PocketMageOS/src/OS_APPS/CALENDAR.cpp
+++ b/Code/PocketMageOS/src/OS_APPS/CALENDAR.cpp
@@ -45,8 +45,8 @@ constexpr int CAL_EDIT_PITCH    = 22;    // event editor/viewer: value row pitch
 constexpr int CAL_EDIT_TEXT_W   = CAL_DAY_LIST_X + CAL_DAY_LIST_W - CAL_EDIT_X;  // 203: value text width
 constexpr int CAL_NOTE_Y0       = CAL_EDIT_Y0 + (5 * CAL_EDIT_PITCH);  // event note: first line baseline
 constexpr int CAL_NOTE_SCROLL_X = CAL_EDIT_X + CAL_EDIT_TEXT_W + 1;   // event note: scrollbar x
-constexpr int CAL_NOTE_SCROLL_Y = CAL_NOTE_Y0 - 18;                   // event note: scrollbar track y
-constexpr int CAL_NOTE_SCROLL_H = kEinkContentH - CAL_NOTE_SCROLL_Y;  // event note: scrollbar track height
+constexpr int CAL_NOTE_SCROLL_Y = CAL_NOTE_Y0 - 18 + 2;                   // event note: scrollbar track y (top inset)
+constexpr int CAL_NOTE_SCROLL_H = kEinkContentH - CAL_NOTE_SCROLL_Y - 2;  // event note: scrollbar track height (bottom inset)
 
 enum CalendarState { WEEK, MONTH, NEW_EVENT, VIEW_EVENT, SUN, MON, TUE, WED, THU, FRI, SAT };
 CalendarState CurrentCalendarState = MONTH;
@@ -70,7 +70,7 @@ String newEventDuration = "";
 String newEventRepeat = "";
 String newEventNote = "";
 static std::vector<String> wrappedEventNoteLines;
-static ulong eventNoteScrollIndex = 0;
+static int eventNoteScrollIndex = 0;
 
 std::vector<std::vector<String>> dayEvents;
 std::vector<std::vector<String>> calendarEvents;
@@ -95,6 +95,14 @@ inline int eventNoteVisibleLines() {
 void resetEventNoteScroll() {
   eventNoteScrollIndex = 0;
   wrappedEventNoteLines = wordWrap(newEventNote, CAL_EDIT_TEXT_W, FontStyle::Body);
+}
+
+inline bool updateEventNoteScrollFromTouch(int maxScroll) {
+  // The shared touch helper uses ulong&, while Calendar keeps signed scroll bounds.
+  ulong touchScrollIndex = eventNoteScrollIndex;
+  bool updateScreen = TOUCH().updateScroll(maxScroll, touchScrollIndex);
+  eventNoteScrollIndex = static_cast<int>(touchScrollIndex);
+  return updateScreen;
 }
 
 void updateEventArray();
@@ -1265,7 +1273,7 @@ void processKB_CALENDAR() {
     case VIEW_EVENT:
       {
         int maxNoteScroll = max(0, (int)wrappedEventNoteLines.size() - eventNoteVisibleLines());
-        if (TOUCH().updateScroll(maxNoteScroll, eventNoteScrollIndex)) {
+        if (updateEventNoteScrollFromTouch(maxNoteScroll)) {
           newState = true;
         }
       }
@@ -1325,17 +1333,6 @@ void processKB_CALENDAR() {
             else if (note != "_EXIT_") {
               newEventNote = note;
               resetEventNoteScroll();
-              newState = true;
-            }
-          }
-          else if (inchar == '7' && eventNoteScrollIndex > 0) {
-            eventNoteScrollIndex--;
-            newState = true;
-          }
-          else if (inchar == '8') {
-            int maxNoteScroll = max(0, (int)wrappedEventNoteLines.size() - eventNoteVisibleLines());
-            if (eventNoteScrollIndex < (ulong)maxNoteScroll) {
-              eventNoteScrollIndex++;
               newState = true;
             }
           }
@@ -1528,9 +1525,9 @@ void einkHandler_CALENDAR() {
 
         int visibleNoteLines = eventNoteVisibleLines();
         int maxNoteScroll = max(0, (int)wrappedEventNoteLines.size() - visibleNoteLines);
-        if (eventNoteScrollIndex > (ulong)maxNoteScroll) eventNoteScrollIndex = maxNoteScroll;
+        if (eventNoteScrollIndex > maxNoteScroll) eventNoteScrollIndex = maxNoteScroll;
 
-        int noteEnd = min((int)wrappedEventNoteLines.size(), (int)eventNoteScrollIndex + visibleNoteLines);
+        int noteEnd = min((int)wrappedEventNoteLines.size(), eventNoteScrollIndex + visibleNoteLines);
         for (int i = eventNoteScrollIndex; i < noteEnd; i++) {
           int noteY = CAL_NOTE_Y0 + ((i - eventNoteScrollIndex) * einkRowPitch(FontStyle::Body));
           FontEngine::drawText(DisplayTarget::EINK, CAL_EDIT_X, noteY, wrappedEventNoteLines[i], FontStyle::Body);

--- a/Code/PocketMageOS/src/OS_APPS/CALENDAR.cpp
+++ b/Code/PocketMageOS/src/OS_APPS/CALENDAR.cpp
@@ -43,6 +43,10 @@ constexpr int CAL_EDIT_X        = 106;   // event editor/viewer: value column x
 constexpr int CAL_EDIT_Y0       = 68;    // event editor/viewer: first value baseline
 constexpr int CAL_EDIT_PITCH    = 22;    // event editor/viewer: value row pitch
 constexpr int CAL_EDIT_TEXT_W   = CAL_DAY_LIST_X + CAL_DAY_LIST_W - CAL_EDIT_X;  // 203: value text width
+constexpr int CAL_NOTE_Y0       = CAL_EDIT_Y0 + (5 * CAL_EDIT_PITCH);  // event note: first line baseline
+constexpr int CAL_NOTE_SCROLL_X = CAL_EDIT_X + CAL_EDIT_TEXT_W + 1;   // event note: scrollbar x
+constexpr int CAL_NOTE_SCROLL_Y = CAL_NOTE_Y0 - 18;                   // event note: scrollbar track y
+constexpr int CAL_NOTE_SCROLL_H = kEinkContentH - CAL_NOTE_SCROLL_Y;  // event note: scrollbar track height
 
 enum CalendarState { WEEK, MONTH, NEW_EVENT, VIEW_EVENT, SUN, MON, TUE, WED, THU, FRI, SAT };
 CalendarState CurrentCalendarState = MONTH;
@@ -65,6 +69,8 @@ String newEventStartTime = "";
 String newEventDuration = "";
 String newEventRepeat = "";
 String newEventNote = "";
+static std::vector<String> wrappedEventNoteLines;
+static ulong eventNoteScrollIndex = 0;
 
 std::vector<std::vector<String>> dayEvents;
 std::vector<std::vector<String>> calendarEvents;
@@ -82,6 +88,15 @@ inline String formatDateDisplay(String yyyymmdd) {
   return yyyymmdd.substring(6, 8) + "/" + yyyymmdd.substring(4, 6) + "/" + yyyymmdd.substring(0, 4);
 }
 
+inline int eventNoteVisibleLines() {
+  return 1 + ((kEinkContentH - CAL_NOTE_Y0) / einkRowPitch(FontStyle::Body));
+}
+
+void resetEventNoteScroll() {
+  eventNoteScrollIndex = 0;
+  wrappedEventNoteLines = wordWrap(newEventNote, CAL_EDIT_TEXT_W, FontStyle::Body);
+}
+
 void updateEventArray();
 void sortEventsByDate(std::vector<std::vector<String>> &calendarEvents);
 
@@ -92,6 +107,8 @@ void CALENDAR_INIT() {
   KB().setKeyboardState(NORMAL);
   monthOffsetCount = 0;
   weekOffsetCount = 0;
+  eventNoteScrollIndex = 0;
+  wrappedEventNoteLines.clear();
 
   updateEventArray();
   sortEventsByDate(calendarEvents);
@@ -760,6 +777,7 @@ void commandSelectDay(String command) {
       newEventRepeat    = evt[4];
       newEventNote      = evt[5];
       currentLine       = "";
+      resetEventNoteScroll();
 
       CurrentCalendarState = VIEW_EVENT;
       KB().setKeyboardState(NORMAL);
@@ -1245,6 +1263,13 @@ void processKB_CALENDAR() {
       break;
 
     case VIEW_EVENT:
+      {
+        int maxNoteScroll = max(0, (int)wrappedEventNoteLines.size() - eventNoteVisibleLines());
+        if (TOUCH().updateScroll(maxNoteScroll, eventNoteScrollIndex)) {
+          newState = true;
+        }
+      }
+
       // Force FUNC state before draining buffer
       KB().setKeyboardState(FUNC); 
       inchar = KB().updateKeypress();
@@ -1297,7 +1322,22 @@ void processKB_CALENDAR() {
           else if (inchar == '6') {
             String note = textPrompt(TR(STR_CAL_EDIT_NOTE));
             if (note == "_RETURN_") return;
-            else if (note != "_EXIT_") { newEventNote = note; newState = true; }
+            else if (note != "_EXIT_") {
+              newEventNote = note;
+              resetEventNoteScroll();
+              newState = true;
+            }
+          }
+          else if (inchar == '7' && eventNoteScrollIndex > 0) {
+            eventNoteScrollIndex--;
+            newState = true;
+          }
+          else if (inchar == '8') {
+            int maxNoteScroll = max(0, (int)wrappedEventNoteLines.size() - eventNoteVisibleLines());
+            if (eventNoteScrollIndex < (ulong)maxNoteScroll) {
+              eventNoteScrollIndex++;
+              newState = true;
+            }
           }
           else if (inchar == '$') { // 'd' in FUNC layer
             if (boolPrompt(TR(STR_CAL_DELETE_Q)) == 1) {
@@ -1485,7 +1525,19 @@ void einkHandler_CALENDAR() {
         FontEngine::drawText(DisplayTarget::EINK, CAL_EDIT_X, CAL_EDIT_Y0 + (2 * CAL_EDIT_PITCH), newEventStartTime, FontStyle::Body);
         FontEngine::drawText(DisplayTarget::EINK, CAL_EDIT_X, CAL_EDIT_Y0 + (3 * CAL_EDIT_PITCH), newEventDuration, FontStyle::Body);
         FontEngine::drawText(DisplayTarget::EINK, CAL_EDIT_X, CAL_EDIT_Y0 + (4 * CAL_EDIT_PITCH), newEventRepeat, FontStyle::Body);
-        FontEngine::drawText(DisplayTarget::EINK, CAL_EDIT_X, CAL_EDIT_Y0 + (5 * CAL_EDIT_PITCH), truncateWithEllipsis(newEventNote, CAL_EDIT_TEXT_W, FontStyle::Body), FontStyle::Body);
+
+        int visibleNoteLines = eventNoteVisibleLines();
+        int maxNoteScroll = max(0, (int)wrappedEventNoteLines.size() - visibleNoteLines);
+        if (eventNoteScrollIndex > (ulong)maxNoteScroll) eventNoteScrollIndex = maxNoteScroll;
+
+        int noteEnd = min((int)wrappedEventNoteLines.size(), (int)eventNoteScrollIndex + visibleNoteLines);
+        for (int i = eventNoteScrollIndex; i < noteEnd; i++) {
+          int noteY = CAL_NOTE_Y0 + ((i - eventNoteScrollIndex) * einkRowPitch(FontStyle::Body));
+          FontEngine::drawText(DisplayTarget::EINK, CAL_EDIT_X, noteY, wrappedEventNoteLines[i], FontStyle::Body);
+        }
+
+        drawScrollbar(wrappedEventNoteLines.size(), visibleNoteLines, eventNoteScrollIndex,
+                      CAL_NOTE_SCROLL_X, CAL_NOTE_SCROLL_Y, CAL_NOTE_SCROLL_H, 3);
 
         EINK().refresh();
       }


### PR DESCRIPTION
## Summary

Calendar event notes were rendered with `truncateWithEllipsis(...)`, so long notes ran out of visible space and could not be read from the event view.

## Changes

- Wrap event notes to the existing note width using the shared `wordWrap(...)` layout helper.
- Display the wrapped lines that fit in the note area (currently two lines).
- Scroll overflowing notes one wrapped line at a time with the touch slider, consistent with other apps.
- Show the existing PocketMage scrollbar only when additional wrapped lines exist, inset from the note area's frame.
- Reset the note scroll position when Calendar is initialized, another event is opened, or the note is edited.

## Testing

- `pio run -e PM_PRODUCTION` — passed
- `pio run -e PM_BETA` — passed
- `pio run -e OTA_APP` — passed
- Reviewed empty, one-line, exactly two-line, overflowing, long-word, non-ASCII/UTF-8 (as supported by the existing font/layout helper), and event-switching behavior.

I do not have physical PocketMage hardware, so e-ink placement/refresh behavior and touch scrolling could not be exercised on-device.

Closes #317

Implementation was developed with AI assistance and reviewed by the contributor.
